### PR TITLE
fixed nlShrinkLWEst function

### DIFF
--- a/R/estimators.R
+++ b/R/estimators.R
@@ -356,7 +356,7 @@ nlShrinkLWEst <- function(dat) {
     Hf_tilde0 <- (1 / pi) * ((3 / 10) * s4 + (s1 / h) * (1 - (1 / 5) * s4) * log_term) * m
 
     # LW Equation C.5
-    d_tilde0 <- 1 / (pi * (p - n) / n * Hf_tilde0)
+    d_tilde0 <- 1 / (pi * (p - eig_nonzero_tol) / eig_nonzero_tol * Hf_tilde0)
 
     # LW Equation C.4
     d_tilde1 <- lambda / ((pi^2 * lambda^2) * (f_tilde^2 + H_tilde^2))

--- a/tests/testthat/test-estimators.R
+++ b/tests/testthat/test-estimators.R
@@ -97,6 +97,16 @@ test_that("LW NLS estimator runs without issue", {
   expect_silent(
     nlShrinkLWEst(mtcars)
   )
+
+  # make sure that nlShrinkLWEst can handle case where n = p
+
+  library(MASS)
+  set.seed(123)
+  Sigma <- matrix(0.5, nrow = 50, ncol = 50) + diag(0.5, nrow = 50)
+  dat <- mvrnorm(n = 50, mu = rep(0, 50), Sigma = Sigma)
+  expect_false(
+    any(is.na(nlShrinkLWEst(dat)))
+  )
 })
 
 # Dense linear Shrinkage Estimator ####################################


### PR DESCRIPTION
`nlShrinkLWEst` would return estimates with `Inf` entries when `n = p` or when the number of approximately non-zero eigenvalues was smaller than `p`. This PR fixes that error, and includes a test to make sure that it doesn't happen in the future.