### PR TITLE
adding references to existing R packages

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -289,3 +289,28 @@
   url = {http://arxiv.org/abs/1802.03426},
   year = {2018}
 }
+
+@manual{lee2019,
+    title = {CovTools: Statistical Tools for Covariance Analysis},
+    author = {Kyoungjae Lee and Kisung You},
+    year = {2019},
+    note = {R package version 0.5.3},
+    url = {https://CRAN.R-project.org/package=CovTools},
+  }
+
+@manual{wang2014,
+    title = {CVTuningCov: Regularized Estimators of Covariance Matrices with CV Tuning},
+    author = {Binhuan Wang},
+    year = {2014},
+    note = {R package version 1.0},
+    url = {https://CRAN.R-project.org/package=CVTuningCov},
+  }
+
+@manual{ramprasad2016,
+    title = {nlshrink: Non-Linear Shrinkage Estimation of Population Eigenvalues and
+Covariance Matrices},
+    author = {Pratik Ramprasad},
+    year = {2016},
+    note = {R package version 1.0.1},
+    url = {https://CRAN.R-project.org/package=nlshrink},
+  }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -71,7 +71,10 @@ As high-dimensional data have become widespread, researchers have derived many
 novel covariance matrix estimators to remediate the sample covariance matrix's
 shortcomings. These estimators come in many flavors, though most are
 constructed by regularizing the sample covariance matrix. Comprehensive
-reviews of these estimators are provided by @fan2016 and @pourahmadi2013.
+reviews are provided by @fan2016 and @pourahmadi2013, and these estimators are
+implemented across a diversity of R packages: `CovTools`
+[@lee2019], `CVTuningCov` [@wang2014], and `nlshrink` [@ramprasad2016] to name
+but a few.
 
 This variety brings with it many challenges. Identifying an "optimal" estimator
 from among a collection of candidates can prove a daunting task, one whose


### PR DESCRIPTION
This PR addresses issue #50. We now cite a handful of R packages that implement high dimensional covariance matrix estimators in the second paragraph of the Statement of Need.