### PR TITLE
Joss review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vignettes/*.html
 .DS_store
 doc
 Meta
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cvCovEst
 Title: Cross-Validated Covariance Matrix Estimation
-Version: 0.3.5
+Version: 0.3.6
 Authors@R: c(
     person("Philippe", "Boileau", email = "philippe_boileau@berkeley.edu",
            role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-# cvCovEst 0.3.4 (2021-02-24)
+# cvCovEst 0.3.6 (2021-06-19)
+
++ Renamed `empirical_risk` column in `risk_df` table output by `cvCovEst()` to
+  `cv_risk`.
++ Added additional citations of existing R packages for covariance matrix
+  estimation in our JOSS submission.
++ Added more comprehensive tests for the available loss functions.
+
+# cvCovEst 0.3.5 (2021-02-24)
 
 + Setting 'LazyLoad' to 'false' in DESCRIPTION to address CRAN checks notes.
 

--- a/R/cvCovEst.R
+++ b/R/cvCovEst.R
@@ -188,11 +188,11 @@ cvCovEst <- function(
   # compute the true cross-validated risk if true_covar_mat is passed in
   if (is.null(true_cov_mat)) {
 
-    # compute empirical risk
+    # compute cv risk
     cv_results <- fold_results_concat %>%
       dplyr::group_by(.data$estimator, .data$hyperparameters) %>%
-      dplyr::summarise(empirical_risk = mean(.data$loss)) %>%
-      dplyr::arrange(.data$empirical_risk) %>%
+      dplyr::summarise(cv_risk = mean(.data$loss)) %>%
+      dplyr::arrange(.data$cv_risk) %>%
       dplyr::ungroup()
 
     # compute the best estimator's estimate
@@ -239,10 +239,10 @@ cvCovEst <- function(
       dplyr::group_by(.data$estimator, .data$hyperparameters) %>%
       dplyr::summarise(
         true_cv_risk = mean(.data$true_loss),
-        empirical_risk = mean(.data$loss),
+        cv_risk = mean(.data$loss),
         full_data_risk = mean(.data$full_mat_loss)
       ) %>%
-      dplyr::arrange(.data$empirical_risk) %>%
+      dplyr::arrange(.data$cv_risk) %>%
       dplyr::ungroup()
 
     # compute the risk difference ratio under the cross-validated risk

--- a/R/estimator_plots.R
+++ b/R/estimator_plots.R
@@ -74,7 +74,7 @@ plotRobustPoetEst <- function(
         geom_path(
           aes(
             x = .data$k,
-            y = .data$empirical_risk,
+            y = .data$cv_risk,
             color = .data$lambda
           )
         ) +
@@ -96,7 +96,7 @@ plotRobustPoetEst <- function(
         geom_path(
           aes(
             x = .data$lambda,
-            y = .data$empirical_risk,
+            y = .data$cv_risk,
             color = .data$k
           )
         ) +
@@ -180,7 +180,7 @@ plotPoetEst <- function(
       geom_path(
         aes(
           x = .data$k,
-          y = .data$empirical_risk,
+          y = .data$cv_risk,
           color = .data$lambda
         )
       ) +
@@ -202,7 +202,7 @@ plotPoetEst <- function(
       geom_path(
         aes(
           x = .data$lambda,
-          y = .data$empirical_risk,
+          y = .data$cv_risk,
           color = .data$k
         )
       ) +
@@ -284,7 +284,7 @@ plotAdaptiveLassoEst <- function(
       geom_path(
         aes(
           x = .data$n,
-          y = .data$empirical_risk,
+          y = .data$cv_risk,
           color = .data$lambda
         )
       ) +
@@ -306,7 +306,7 @@ plotAdaptiveLassoEst <- function(
       geom_path(
         aes(
           x = .data$lambda,
-          y = .data$empirical_risk,
+          y = .data$cv_risk,
           color = .data$n
         )
       ) +

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -812,7 +812,7 @@ cvRiskPlot <- function(
       dplyr::arrange(.data$hyperparameters, .by_group = TRUE)
 
     final_plot2 <- ggplot(risk) +
-      geom_path(aes(x = .data$hyperparameters, y = .data$empirical_risk)) +
+      geom_path(aes(x = .data$hyperparameters, y = .data$cv_risk)) +
       facet_wrap(facets = vars(.data$estimator), scales = "free_x") +
       labs(
         title = "Estimator Cross-Validated Risk",

--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -23,12 +23,12 @@ cvRiskByClass <- function(dat) {
   cv_risk <- dat %>%
     dplyr::group_by(.data$estimator) %>%
     dplyr::summarise(
-      Min = min(.data$empirical_risk),
-      Q1 = quantile(.data$empirical_risk, probs = 0.25, type = 3),
-      Median = quantile(.data$empirical_risk, probs = 0.5, type = 3),
-      Q3 = quantile(.data$empirical_risk, probs = 0.75, type = 3),
-      Max = max(.data$empirical_risk),
-      Mean = mean(.data$empirical_risk),
+      Min = min(.data$cv_risk),
+      Q1 = quantile(.data$cv_risk, probs = 0.25, type = 3),
+      Median = quantile(.data$cv_risk, probs = 0.5, type = 3),
+      Q3 = quantile(.data$cv_risk, probs = 0.75, type = 3),
+      Max = max(.data$cv_risk),
+      Mean = mean(.data$cv_risk),
       .groups = "keep"
     ) %>%
     dplyr::arrange(.data$Mean)
@@ -64,20 +64,20 @@ bestInClass <- function(dat, worst = FALSE) {
       dplyr::group_by(.data$estimator) %>%
       dplyr::summarise(
         hyperparameter = dplyr::last(.data$hyperparameters),
-        empirical_risk = dplyr::last(.data$empirical_risk),
+        cv_risk = dplyr::last(.data$cv_risk),
         .groups = "keep"
       ) %>%
-      dplyr::arrange(.data$empirical_risk)
+      dplyr::arrange(.data$cv_risk)
   }
   else {
     inClass <- dat %>%
       dplyr::group_by(.data$estimator) %>%
       dplyr::summarise(
         hyperparameter = dplyr::first(.data$hyperparameters),
-        empirical_risk = dplyr::first(.data$empirical_risk),
+        cv_risk = dplyr::first(.data$cv_risk),
         .groups = "keep"
       ) %>%
-      dplyr::arrange(.data$empirical_risk)
+      dplyr::arrange(.data$cv_risk)
   }
   return(inClass)
 }
@@ -116,10 +116,10 @@ hyperRisk <- function(dat) {
     hyper_summ <- lapply(hyper_est, function(est) {
       h <- dat %>%
         dplyr::filter(.data$estimator == est) %>%
-        dplyr::mutate(empirical_risk = round(.data$empirical_risk))
+        dplyr::mutate(cv_risk = round(.data$cv_risk))
 
       risk_stats <- quantile(
-        h$empirical_risk,
+        h$cv_risk,
         probs = c(0, 0.25, 0.50, 0.75, 1),
         type = 3
       )
@@ -127,11 +127,11 @@ hyperRisk <- function(dat) {
       hyper_risk <- sapply(unname(risk_stats), function(r) {
         # Filter by the quantiles of the empirical risk
         hr <- h %>%
-          dplyr::filter(.data$empirical_risk == r)
+          dplyr::filter(.data$cv_risk == r)
 
         vec <- c(
           dplyr::first(hr$hyperparameters),
-          dplyr::first(hr$empirical_risk)
+          dplyr::first(hr$cv_risk)
         )
 
         return(vec)
@@ -142,7 +142,7 @@ hyperRisk <- function(dat) {
         stat = c("min", "Q1", "median", "Q3", "max")
       )
 
-      colnames(df) <- c("hyperparameters", "empirical_risk", "stat")
+      colnames(df) <- c("hyperparameters", "cv_risk", "stat")
       df <- tibble::as_tibble(df)
 
       return(df)

--- a/README.md
+++ b/README.md
@@ -89,17 +89,17 @@ cv_cov_est_out <- cvCovEst(
 # NOTE: the estimated covariance matrix is accessible via the `$estimate` slot
 cv_cov_est_out$risk_df
 #> # A tibble: 9 x 3
-#>   estimator            hyperparameters      empirical_risk
-#>   <chr>                <chr>                         <dbl>
-#> 1 linearShrinkLWEst    hyperparameters = NA           357.
-#> 2 poetEst              lambda = 0.2, k = 1            369.
-#> 3 poetEst              lambda = 0.2, k = 2            372.
-#> 4 poetEst              lambda = 0.1, k = 2            375.
-#> 5 poetEst              lambda = 0.1, k = 1            376.
-#> 6 denseLinearShrinkEst hyperparameters = NA           379.
-#> 7 sampleCovEst         hyperparameters = NA           379.
-#> 8 thresholdingEst      gamma = 0.2                    384.
-#> 9 thresholdingEst      gamma = 2                      826.
+#>   estimator            hyperparameters      cv_risk
+#>   <chr>                <chr>                  <dbl>
+#> 1 linearShrinkLWEst    hyperparameters = NA    357.
+#> 2 poetEst              lambda = 0.2, k = 1     369.
+#> 3 poetEst              lambda = 0.2, k = 2     372.
+#> 4 poetEst              lambda = 0.1, k = 2     375.
+#> 5 poetEst              lambda = 0.1, k = 1     376.
+#> 6 denseLinearShrinkEst hyperparameters = NA    379.
+#> 7 sampleCovEst         hyperparameters = NA    379.
+#> 8 thresholdingEst      gamma = 0.2             384.
+#> 9 thresholdingEst      gamma = 2               826.
 ```
 
 ------------------------------------------------------------------------

--- a/tests/testthat/test-cvCovEst.R
+++ b/tests/testthat/test-cvCovEst.R
@@ -9,7 +9,6 @@ Sigma <- matrix(0.5, nrow = 10, ncol = 10) + diag(0.5, nrow = 10)
 # sample 50 observations from multivariate normal with mean = 0, var = Sigma
 dat <- mvrnorm(n = 50, mu = rep(0, 10), Sigma = Sigma)
 
-# simple test
 test_that("cross-validated covariance selector runs silently", {
   expect_silent(cvCovEst(
     dat = dat,


### PR DESCRIPTION
This PR addresses the issue raised in #49:
+ The `empirical_risk` variable in the `risk_df` table output by `cvCovEst()` is renamed to `cv_risk` to avoid confusion
+ Added more manual tests for the loss functions