### PR TITLE
addressing spelling and formatting errors identified by JOSS editor

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -314,3 +314,11 @@ Covariance Matrices},
     note = {R package version 1.0.1},
     url = {https://CRAN.R-project.org/package=nlshrink},
   }
+
+@Manual{pkgdown,
+  title = {pkgdown: Make Static HTML Documentation for a Package},
+  author = {Hadley Wickham and Jay Hesselberth},
+  year = {2020},
+  note = {R package version 1.6.1},
+  url = {https://CRAN.R-project.org/package=pkgdown}
+}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -60,7 +60,7 @@
 
 @misc{future,
   author = {Bengtsson, Henrik},
-  title = {A Unifying Framework for Parallel and Distributed Processing in R
+  title = {A Unifying Framework for Parallel and Distributed Processing in {R}
     using Futures},
   year = {2020},
   month = {aug},
@@ -95,7 +95,7 @@
 }
 
 @article{Bickel2008_thresh,
-  author = {Bickel, Peter J and Levita, Elizaveta},
+  author = {Bickel, Peter J and Levina, Elizaveta},
   doi = {10.1214/08-AOS600},
   journal = {Annals of Statistics},
   month = {12},
@@ -109,7 +109,7 @@
 }
 
 @article{bickel2008_banding,
-  author = {Bickel, Peter J and Levita, Elizaveta},
+  author = {Bickel, Peter J and Levina, Elizaveta},
   doi = {10.1214/009053607000000758},
   journal = {Annals of Statistics},
   month = {02},
@@ -154,7 +154,7 @@
   author = {Olivier Ledoit and Michael Wolf},
   title = {{Analytical nonlinear shrinkage of large-dimensional covariance matrices}},
   volume = {48},
-  journal = {The Annals of Statistics},
+  journal = {Annals of Statistics},
   number = {5},
   publisher = {Institute of Mathematical Statistics},
   pages = {3043 -- 3065},
@@ -253,13 +253,14 @@
   Series = {Wiley series in probability and statistics},
   Title = {High-dimensional covariance estimation},
   Year = {2013},
+  ISBN = {978-1-118-03429-3}
 }
 
 @article{johnstone2001distribution,
   author = {Iain M. Johnstone},
   title = {{On the distribution of the largest eigenvalue in principalcomponents analysis}},
   volume = {29},
-  journal = {The Annals of Statistics},
+  journal = {Annals of Statistics},
   number = {2},
   publisher = {Institute of Mathematical Statistics},
   pages = {295 -- 327},
@@ -307,7 +308,7 @@
   }
 
 @manual{ramprasad2016,
-    title = {nlshrink: Non-Linear Shrinkage Estimation of Population Eigenvalues and
+    title = {{nlshrink}: Non-Linear Shrinkage Estimation of Population Eigenvalues and
 Covariance Matrices},
     author = {Pratik Ramprasad},
     year = {2016},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -192,8 +192,8 @@ plot(cv_cov_est_sim, data_orig = sim_dat)
 ```
 
 ![A summary of the `cvCovEst` procedure's results. In the top left corner, the
-selected estmators risk is plotted against its considered hyperparameters. In
-the rop right, the eigenvalues of the selected estimator's estimate are
+selected estimator's risk is plotted against its considered hyperparameters. In
+the top right, the eigenvalues of the selected estimator's estimate are
 displayed. The bottom left plot presents the estimated covariance matrix.
 Entries are colored based on their absolute values. Finally, the table in the
 bottom right summarizes the performance of the best estimators from each class.
@@ -224,7 +224,7 @@ dimensionality reduction.
 
 Indeed, we find that the two-dimensional UMAP embedding resulting from the
 `cvCovEst`-based approach improves upon that of the standard PCA-based approach
-when applied to a dataset of 285 mouse visual coretex's cells' 1,000 most
+when applied to a dataset of 285 mouse visual cortex's cells' 1,000 most
 variable genes [@tasic2016]. Fewer rare cells are misclustered, engendering a
 47\% improvement in average silhouette width. For further discussion, see
 @boileau2021.
@@ -238,8 +238,8 @@ A stable release of the `cvCovEst` package is freely-available via the
 [Comprehensive `R` Archive Network](https://CRAN.R-project.org/package=cvCovEst).
 Its development version can be found on
 [GitHub](https://github.com/PhilBoileau/cvCovEst). Documentation and examples
-are contained in each version's manual pages, vignette, and `pkgdown` website
-at https://philboileau.github.io/cvCovEst.
+are contained in each version's manual pages, vignette, and `pkgdown` [@pkgdown]
+website at https://philboileau.github.io/cvCovEst.
 
 # Acknowledgments
 


### PR DESCRIPTION
Addressing spelling and formatting errors identified by JOSS editor:
- "Levita" has been changed to "Levina"
- "R" is capitalized in the Bengttson reference
- "The Annals of Statistics" has been changed to "Annals of Statistics"
- The ISBN for Pourehmadi's book has been included in the bibtex reference
- `nlshrink`'s title is now fixed in the bibliography
- The typo in Figure 1's caption has been fixed
- `pkgdown` is now cited where appropriate
