### PR TITLE
Fix inconsistency in linearShrinkLWEst()

### DIFF
--- a/R/estimators.R
+++ b/R/estimators.R
@@ -74,7 +74,7 @@ linearShrinkLWEst <- function(dat) {
   m_n <- matrixStats::sum2(sample_cov_mat * idn_pn) / p_n
   d_n_2 <- matrixStats::sum2((sample_cov_mat - m_n * idn_pn)^2) / p_n
   b_bar_n_2 <- apply(
-    dat, 1,
+    scale(dat, center = TRUE, scale = FALSE), 1,
     function(x) {
       matrixStats::sum2((tcrossprod(x) - sample_cov_mat)^2)
     }


### PR DESCRIPTION
E.g. try
```r
linearShrinkLWEst(iris[1:4])
linearShrinkLWEst(iris[1:4] - 4)
```